### PR TITLE
Support multiple allowed definition type

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ $validator->defineType('User', [
     'name' => 'string',
     'gender' => 'string',
     'age' => '?integer',
+    'rating' => '?integer,?boolean',
 ]);
 ```
 
-This example defines a custom type named `User`, which have three properties. name and gender require be a
-string, age requires be an integer but allows to be nullable.
+This example defines a custom type named `User`, which have four properties. name and gender require be a
+string, age requires be an integer but allows to be nullable, and rating required to integer but allows to be null or boolean.
 
 #### 2. Define a list type
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -244,9 +244,36 @@ class Validator
             if ($data === null) {
                 return true;
             }
-            $type = substr($type, 1);
+
+            if (strpos($type, ',') !== false) {
+
+                $option = explode(',', $type);
+
+                $types = [];
+                foreach ($option as $key) {
+                    if ($this->getType($data) === substr($key, 1)) {
+                        return true;
+                    }
+                    $types[] = substr($key, 1);
+                }
+
+                $type = $types;
+            } else {
+                $type = substr($type, 1);
+            }
         }
 
+        if ($this->isArray($type)) {
+            foreach ($type as $key) {
+                return $this->matchInternalProcess($data, $key);
+            }
+        } else {
+            return $this->matchInternalProcess($data, $type);
+        }
+    }
+
+    protected function matchInternalProcess($data, $type)
+    {
         if (!is_string($type)) {
             $definition = $type;
         } else if (isset($this->types[$type])) {


### PR DESCRIPTION
sometime, value from api response isn't indeterminate,
I've some problem with that to validate, this is an example:

```php
<?php
$data = [
    [
        'name'   => 'Bob',
        'rating' => 4.1,
    ],
    [
        'name'   => 'Foo',
        'rating' => 4,
    ],
    [
        'name'   => 'Baz',
        'rating' => null,
    ],
];
```
So, we need to validate not only the required and null type.
I think use definition `?double,?integer` can solving this problem to validate `rating` key with multi possibility type.